### PR TITLE
Fix for the missing count for newer pet items

### DIFF
--- a/CritterItems.lua
+++ b/CritterItems.lua
@@ -1,4 +1,4 @@
-
+--[=[
 local addon_name, addon = ...
 
 --
@@ -884,3 +884,4 @@ do
         updateFrame:Show()
     end
 end
+]=]

--- a/Tooltips.lua
+++ b/Tooltips.lua
@@ -250,7 +250,7 @@ function module:AlterGameTooltip(tt)
         if link then
             local _, _, itemid = strfind(link, "|Hitem:(%d+):")
             if itemid then
-                local speciesID = addon.Item2Species[tonumber(itemid)]
+                local speciesID = select(13, C_PetJournal.GetPetInfoByItemID(itemid))
                 if speciesID then
                     if not addon.db.profile.itemTipIncludesAll then
                         local _, _, _, _, _, _, _, canBattle = C_PetJournal.GetPetInfoBySpeciesID(speciesID)


### PR DESCRIPTION
[This PR belongs to [this Issue](https://github.com/GurliGebis/WoWAddon-BattlePetCountNG/issues/5). You find additional info there.]

Besides implementing the `GetPetInfoByItemID` function, I also outcommented the entire contents of CritterItems.lua, the file containing the obsolete table.

You can probably delete the file, but I left it in outcommented form because it contains also code for a slash command and two "Exceptions" tables associated with that slash command. 

It seems to me that the only purpose of this slash command is to show a list of species that are in the Pet Journal but not in the `Item2Species` table, which would mean that the slash command is also obsolete.

In any case, if the slash command has some other use that I have missed, you can simply reactivate the code.
