### PR TITLE
Correct battle pet tooltip dimensions (for compatibility with other addons)

### DIFF
--- a/Tooltips.lua
+++ b/Tooltips.lua
@@ -123,7 +123,8 @@ function module:BattlePetToolTip_Show(speciesID, level, breedQuality, maxHealth,
         Owned:SetText(addon:CollectedText(speciesID))
         Owned:Show()
 
-        tip:SetSize(260,122+Owned:GetHeight())
+        local height = tip:GetHeight() + Owned:GetHeight() - 12
+        tip:SetHeight(height)
     end
 end
 


### PR DESCRIPTION
Calculate the tooltip height using the real tooltip height, instead of a hardcoded height value. (I also removed the width change, as it doesn't seem to be necessary and leads to an ugly different width from attached tooltips.)

The `-12` are for compensating for superfluous vertical whitespace at the bottom, somehow produced by the BPC lines. I don't know why this space gets added, but I'm not a tooltip expert either… I tested the `-12` on two different displays with different resolutions and scalings, and it is OK on both.

With this fix, BPC can be used together with other addons that add to the pet tooltip.

Example, with tooltip lines from BPC, Baganator, Auctionator, TipTac:

Before (overflowing lines):

<img width="336" alt="before-fs8" src="https://github.com/GurliGebis/WoWAddon-BattlePetCountNG/assets/1410282/332fdba6-51ff-4dcc-bef8-9791df60a730">

 
Fixed (all lines within the backdrop):

<img width="342" alt="after-fs8" src="https://github.com/GurliGebis/WoWAddon-BattlePetCountNG/assets/1410282/653848d5-476b-457f-997a-2651e2674975">

 
Works also together with attached subtooltips from other addons:

<details>
<summary>Screenshot</summary>
<img width="522" alt="afterWithAttached-fs8" src="https://github.com/GurliGebis/WoWAddon-BattlePetCountNG/assets/1410282/c86e1c9c-fe10-4f3c-b6d6-2f0b9cd03186">
</details> 
