### PR TITLE
Workaround: Attach extra attached pet tooltip at top, to avoid overlapping

### DIFF
--- a/Tooltips.lua
+++ b/Tooltips.lua
@@ -62,8 +62,8 @@ function module:SubTip(tooltip, text)
     if not subtip then
         subtip = LibQTip:Acquire(tooltip:GetName().."_BPC_SubTip", 1, "LEFT")
 
-        subtip:SetPoint("TOPLEFT", tooltip, "BOTTOMLEFT")
-        subtip:SetPoint("TOPRIGHT", tooltip, "BOTTOMRIGHT") 
+        subtip:SetPoint("BOTTOMLEFT", tooltip, "TOPLEFT")
+        subtip:SetPoint("BOTTOMRIGHT", tooltip, "TOPRIGHT")
         subtip:Show()
 
         tooltip.X_BPC2 = subtip


### PR DESCRIPTION
If BPC's pet tooltip is set to "extra attached tooltip", it gets overlapped by other "extra" tooltips (or overlaps others).

This could probably be fixed  _properly_ by modifying the anchoring, but I don't know how to do it, and currently I don't have the time to find it out.

So, this is just an improvised fix (workaround), which is also the reason that I separated it from my other tooltip PR.

**Before (BPC behind others):**

<img width="532" alt="before2-fs8" src="https://github.com/GurliGebis/WoWAddon-BattlePetCountNG/assets/1410282/7f1a6852-fcc1-4cc2-bbdf-58335b29bb74">
 

**After (at top):**

<img width="522" alt="after2-fs8" src="https://github.com/GurliGebis/WoWAddon-BattlePetCountNG/assets/1410282/48cef7f6-06ee-4e58-a457-9860b0e24942">
