### PR TITLE
Adjust margin for AH tooltip

### DIFF
--- a/Tooltips.lua
+++ b/Tooltips.lua
@@ -123,7 +123,15 @@ function module:BattlePetToolTip_Show(speciesID, level, breedQuality, maxHealth,
         Owned:SetText(addon:CollectedText(speciesID))
         Owned:Show()
 
-        local height = tip:GetHeight() + Owned:GetHeight() - 12
+        local ownedCount = C_PetJournal.GetNumCollectedInfo(speciesID)
+        local heightModifier
+        if ownedCount > 0 then
+            heightModifier = 12
+        else
+            heightModifier = -2
+        end
+
+        local height = tip:GetHeight() + Owned:GetHeight() - heightModifier
         tip:SetHeight(height)
     end
 end


### PR DESCRIPTION
Not sure why this is needed, but it appears to fix the auction house margin issue discussed in https://github.com/GurliGebis/WoWAddon-BattlePetCompletionist/issues/60